### PR TITLE
Fix add/sub Formula objects

### DIFF
--- a/src/lipyd/formula.py
+++ b/src/lipyd/formula.py
@@ -211,12 +211,12 @@ class Formula(mass.MassBase, mz.Mz):
             
             return self
         
-        for elem, cnt in iteritems(self.atoms):
+        for elem, cnt in iteritems(self._atoms):
             
             self.counts[elem] = cnt * other
         
         self.calc_mass()
-        self.formula_from_dict(self.atoms)
+        self.formula_from_dict(self._atoms)
         self.isotope = self.isotope * other
     
     def __mul__(self, other):
@@ -227,7 +227,7 @@ class Formula(mass.MassBase, mz.Mz):
         
         new_atoms = defaultdict(int)
         
-        for elem, cnt in iteritems(self.atoms):
+        for elem, cnt in iteritems(self._atoms):
             
             new_atoms[elem] = cnt * other
         
@@ -254,7 +254,7 @@ class Formula(mass.MassBase, mz.Mz):
         Returns this ``Formula`` instance as ``mass.MassBase`` object.
         """
         
-        return MassBase(self.formula, self.charge, self.isotope)
+        return mass.MassBase(self.formula, self.charge, self.isotope)
     
     
     def add(self, formula):
@@ -268,7 +268,7 @@ class Formula(mass.MassBase, mz.Mz):
         """
         
         for elem, cnt in mass._re_form.findall(formula):
-            self.atoms[elem] += int(cnt or '1')
+            self._atoms[elem] += int(cnt or '1')
         
         self.update()
     
@@ -284,9 +284,9 @@ class Formula(mass.MassBase, mz.Mz):
         """
         
         for elem, cnt in mass._re_form.findall(formula):
-            self.atoms[elem] -= int(cnt or '1')
+            self._atoms[elem] -= int(cnt or '1')
             
-            if self.atoms[elem] < 0:
+            if self._atoms[elem] < 0:
                 
                 raise ValueError('Can not remove %s from %s: '
                     'too few %s atoms!' % (formula, self.formula, elem))
@@ -300,10 +300,10 @@ class Formula(mass.MassBase, mz.Mz):
         re-calculates the mass.
         """
         
-        if len(self.atoms):
+        if len(self._atoms):
             
-            self.formula = ''.join('%s%u' % (elem, self.atoms[elem])
-                                    for elem in sorted(self.atoms.keys()))
+            self.formula = ''.join('%s%u' % (elem, self._atoms[elem])
+                                    for elem in sorted(self._atoms.keys()))
             self.calc_mass()
     
     

--- a/src/lipyd/formula.py
+++ b/src/lipyd/formula.py
@@ -179,7 +179,7 @@ class Formula(mass.MassBase, mz.Mz):
     
     def __sub__(self, other):
         
-        new = copy.copy(self)
+        new = copy.deepcopy(self)
         new.__isub__(other)
         return new
     

--- a/src/lipyd/formula.py
+++ b/src/lipyd/formula.py
@@ -203,6 +203,9 @@ class Formula(mass.MassBase, mz.Mz):
         self.charge -= (other.charge if hasattr(other, 'charge') else 0)
         self.isotope -= (other.isotope if hasattr(other, 'isotope') else 0)
         
+        self.calc_mass()
+        self.update_mz()
+        
         return self
     
     def __imul__(self, other):

--- a/src/lipyd/mass.py
+++ b/src/lipyd/mass.py
@@ -572,7 +572,7 @@ class MassBase(object):
                 )
                 m = 0.0
                 for element, count in atoms:
-                    count = int(count or '1')
+                    count = int('1' if count == '' else count)
                     m += self.exmass[element] * count
                 
                 if self.isotope:


### PR DESCRIPTION
Substractions of `Formula` objects does not work:
```python
>>> (formula.Formula('CH4') - formula.Formula('H')).formula
'C1H4'
```

In `Formula`object, `_atoms` should be used instead of `atoms` property to do calculations as `atoms` is automatically recalculated from `formula`.